### PR TITLE
Reconnect the cinder-volumes loopback devices after a reboot

### DIFF
--- a/manifests/profile/cinder.pp
+++ b/manifests/profile/cinder.pp
@@ -9,4 +9,11 @@ class deployments::profile::cinder
   include ::cinder::scheduler
   include ::cinder::volume
   include ::cinder::setup_test_volume
+
+  file { '/etc/init/cinder-loopback.conf':
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+    content => template('deployments/cinder-loopback.conf.erb'),
+  }
 }

--- a/templates/cinder-loopback.conf.erb
+++ b/templates/cinder-loopback.conf.erb
@@ -1,0 +1,10 @@
+description "Setup loopback mounts for Cinder on reboot"
+
+start on mounted MOUNTPOINT=/
+task
+
+script
+    # assume puppet already made the volume file in /var/lib/cinder
+    losetup <%= scope.function_hiera(['cinder::setup_test_volume::loopback_device']) %> <%= scope.function_hiera(['cinder::setup_test_volume::volume_path']) %>/<%= scope.function_hiera(['cinder::setup_test_volume::volume_name']) %>
+end script
+


### PR DESCRIPTION
This will remount the cinder loopback device after a reboot,
it will not re-create it if removed however.
