### PR TITLE
Remove deprecated/unused ceilometer alarm eval

### DIFF
--- a/manifests/profile/ceilometer.pp
+++ b/manifests/profile/ceilometer.pp
@@ -7,7 +7,6 @@ class deployments::profile::ceilometer
   include ::ceilometer::agent::central
   include ::ceilometer::agent::notification
   include ::ceilometer::alarm::notifier
-  include ::ceilometer::alarm::evaluator
   include ::ceilometer::api
   include ::ceilometer::config
   include ::ceilometer::db


### PR DESCRIPTION
Has no function in Mitaka
