### PR TITLE
Run polling agents on PC compute hosts

### DIFF
--- a/manifests/role/foundations_compute_public_cloud.pp
+++ b/manifests/role/foundations_compute_public_cloud.pp
@@ -1,8 +1,8 @@
-class deployments::role::foundations_compute {
+class deployments::role::foundations_compute_public_cloud {
   include deployments::profile::base
   include deployments::profile::compute
   include ::ceilometer::agent::polling
   include ::ceilometer::agent::auth
 }
 
-include deployments::role::foundations_compute
+include deployments::role::foundations_compute_public_cloud

--- a/manifests/role/foundations_compute_public_cloud.pp
+++ b/manifests/role/foundations_compute_public_cloud.pp
@@ -1,0 +1,8 @@
+class deployments::role::foundations_compute {
+  include deployments::profile::base
+  include deployments::profile::compute
+  include ::ceilometer::agent::polling
+  include ::ceilometer::agent::auth
+}
+
+include deployments::role::foundations_compute


### PR DESCRIPTION
public cloud compute hosts need polling agents to gather ceilometer data
