### PR TITLE
Polling should not be on the controller

### DIFF
--- a/manifests/profile/ceilometer.pp
+++ b/manifests/profile/ceilometer.pp
@@ -6,7 +6,6 @@ class deployments::profile::ceilometer
   include ::ceilometer::agent::auth
   include ::ceilometer::agent::central
   include ::ceilometer::agent::notification
-  include ::ceilometer::agent::polling
   include ::ceilometer::alarm::notifier
   include ::ceilometer::api
   include ::ceilometer::config


### PR DESCRIPTION
The regular polling agent alone shouldn't be on the controller, it should go on the compute node.

Some polling stuff (including the polling package) is pulled in by the central module, and we do want that on the controller.
