### PR TITLE
Remove no-op ceilometer alarm notifier class

### DIFF
--- a/manifests/profile/ceilometer.pp
+++ b/manifests/profile/ceilometer.pp
@@ -6,7 +6,6 @@ class deployments::profile::ceilometer
   include ::ceilometer::agent::auth
   include ::ceilometer::agent::central
   include ::ceilometer::agent::notification
-  include ::ceilometer::alarm::notifier
   include ::ceilometer::api
   include ::ceilometer::config
   include ::ceilometer::db


### PR DESCRIPTION
This class was made a no-op class in Mitaka [1] and so we'll remove it
to drop a deprecation warning.

[1] -
https://github.com/openstack/puppet-ceilometer/blob/stable/mitaka/manifests/alarm/notifier.pp#L40
